### PR TITLE
Avoid communicate with Javascript when media is paused

### DIFF
--- a/build_electron.cmd
+++ b/build_electron.cmd
@@ -1,5 +1,5 @@
 set npm_config_wcjs_runtime="electron"
-set npm_config_wcjs_runtime_version="0.33.9"
-set npm_config_wcjs_arch="ia32"
+set npm_config_wcjs_runtime_version="1.6.11"
+set npm_config_wcjs_arch="x64"
 
 npm install

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -365,11 +365,9 @@ void JsVlcPlayer::initLibvlc( const v8::Local<v8::Array>& vlcOpts )
         _libvlc = libvlc_new( static_cast<int>( libvlcOpts.size() ), libvlcOpts.data() );
     }
 
-#if defined(_DEBUG)
     if( _libvlc ) {
         libvlc_log_set(_libvlc, JsVlcPlayer::log_event_wrapper, this);
     }
-#endif
 }
 
 JsVlcPlayer::~JsVlcPlayer()
@@ -420,6 +418,7 @@ inline int _vscprintf( const char* format, va_list argptr )
 
 void JsVlcPlayer::log_event( int level, const libvlc_log_t *ctx, const char *fmt, va_list args )
 {
+#if defined(_DEBUG)
     va_list argsCopy;
     va_copy( argsCopy, args );
     int messageSize = _vscprintf( fmt, argsCopy );
@@ -440,6 +439,7 @@ void JsVlcPlayer::log_event( int level, const libvlc_log_t *ctx, const char *fmt
     _asyncDataGuard.unlock();
 
     uv_async_send( &_async );
+#endif
 }
 
 void JsVlcPlayer::handleAsync()

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -365,9 +365,11 @@ void JsVlcPlayer::initLibvlc( const v8::Local<v8::Array>& vlcOpts )
         _libvlc = libvlc_new( static_cast<int>( libvlcOpts.size() ), libvlcOpts.data() );
     }
 
+#if defined(_DEBUG)
     if( _libvlc ) {
         libvlc_log_set(_libvlc, JsVlcPlayer::log_event_wrapper, this);
     }
+#endif
 }
 
 JsVlcPlayer::~JsVlcPlayer()

--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -159,4 +159,6 @@ private:
     v8::UniquePersistent<v8::Object> _jsPlaylist;
 
     uv_timer_t _errorTimer;
+
+    libvlc_time_t _lastTimeFrameReady;
 };


### PR DESCRIPTION
WebChimera.js passes to LibVLC three callbacks: `video_lock_cb`, `video_unlock_cb` and `video_display_cb`. Internally, LibVLC has an internal clock which decides when to update the video. The sequence is the following:
1. LibVLC warns that it will start to decode the next frame, calling the callback video_lock, so we know that we should block all reads in the image memory.
2. Then, it decodes the image in the memory area that we indicated when starting the library.
3. Later, it indicates that the image has been written with the video_unlock callback.
4. Finally, it indicates that the image is already decoded and is ready to be displayed.

If the video is not paused, the frequency of `video_display_cb` callback is equal to the video frame-rate. However, when paused, the frequency is decreased and the callback is called every 110-140ms or so.

It looks like that we can't change this behaviour on LibVLC, so the video decoding process will always be running at said frequency, although it doesn't care, since it's done concurrently in another thread.

Therefore, what we'll check if the frame (current time in the video) decoded is different to the last one sent to Javascript. With this, we won't send anything to Javascript and, therefore, won't update any texture to GPU. This change will save around 2-3ms (on my machine, which is quite good) when video is paused.

Before:
![upload-gpu-on-pause-mod](https://user-images.githubusercontent.com/32394038/31550445-a4c8bea4-b031-11e7-97f9-a8ad9adbdf17.png)

After:
![no-gpu-on-pause-mod](https://user-images.githubusercontent.com/32394038/31550446-a504eabe-b031-11e7-864d-e4d1067f6444.png)
