### PR TITLE
Playback improvements

### DIFF
--- a/src/JsVlcAudio.cpp
+++ b/src/JsVlcAudio.cpp
@@ -98,6 +98,8 @@ JsVlcAudio::JsVlcAudio( v8::Local<v8::Object>& thisObject, JsVlcPlayer* jsPlayer
     _jsPlayer( jsPlayer )
 {
     Wrap( thisObject );
+
+    _jsPlayer->setAudio( *this );
 }
 
 std::string JsVlcAudio::description( uint32_t index )

--- a/src/JsVlcInput.cpp
+++ b/src/JsVlcInput.cpp
@@ -37,6 +37,9 @@ void JsVlcInput::initJsApi()
     SET_RW_PROPERTY( instanceTemplate, "rate",
                      &JsVlcInput::rate,
                      &JsVlcInput::setRate );
+    SET_RW_PROPERTY( instanceTemplate, "rateReverse",
+                     &JsVlcInput::rateReverse,
+                     &JsVlcInput::setRateReverse );
 
     Local<Function> constructor = constructorTemplate->GetFunction();
     _jsConstructor.Reset( isolate, constructor );
@@ -82,14 +85,17 @@ void JsVlcInput::jsCreate( const v8::FunctionCallbackInfo<v8::Value>& args )
 }
 
 JsVlcInput::JsVlcInput( v8::Local<v8::Object>& thisObject, JsVlcPlayer* jsPlayer ) :
-    _jsPlayer( jsPlayer )
+    _jsPlayer( jsPlayer ),
+    _rateReverse( 1.0 )
 {
     Wrap( thisObject );
+
+    _jsPlayer->setInput( *this );
 }
 
 double JsVlcInput::length()
 {
-    return static_cast<double>( _jsPlayer->player().playback().get_length() );
+    return _jsPlayer->length();
 }
 
 double JsVlcInput::fps()
@@ -137,3 +143,12 @@ void JsVlcInput::setRate( double rate )
     _jsPlayer->player().playback().set_rate( static_cast<float>( rate ) );
 }
 
+double JsVlcInput::rateReverse()
+{
+    return _rateReverse;
+}
+
+void JsVlcInput::setRateReverse( double rateReverse )
+{
+    _rateReverse = rateReverse;
+}

--- a/src/JsVlcInput.cpp
+++ b/src/JsVlcInput.cpp
@@ -99,7 +99,7 @@ double JsVlcInput::fps()
 
 unsigned JsVlcInput::state()
 {
-    return _jsPlayer->player().get_state();
+    return _jsPlayer->state();
 }
 
 bool JsVlcInput::hasVout()
@@ -109,22 +109,22 @@ bool JsVlcInput::hasVout()
 
 double JsVlcInput::position()
 {
-    return _jsPlayer->player().playback().get_position();
+    return _jsPlayer->position();
 }
 
 void JsVlcInput::setPosition( double position )
 {
-    _jsPlayer->player().playback().set_position( static_cast<float>( position ) );
+    _jsPlayer->setPosition( position );
 }
 
 double JsVlcInput::time()
 {
-    return static_cast<double>( _jsPlayer->player().playback().get_time() );
+    return _jsPlayer->time();
 }
 
 void JsVlcInput::setTime( double time )
 {
-    return _jsPlayer->player().playback().set_time( static_cast<libvlc_time_t>( time ) );
+    return _jsPlayer->setTime( time );
 }
 
 double JsVlcInput::rate()

--- a/src/JsVlcInput.h
+++ b/src/JsVlcInput.h
@@ -28,6 +28,9 @@ public:
     double rate();
     void setRate( double );
 
+    double rateReverse();
+    void setRateReverse( double );
+
 
 private:
     static void jsCreate( const v8::FunctionCallbackInfo<v8::Value>& args );
@@ -37,4 +40,6 @@ private:
     static v8::Persistent<v8::Function> _jsConstructor;
 
     JsVlcPlayer* _jsPlayer;
+
+    double _rateReverse;
 };

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -599,7 +599,7 @@ void JsVlcPlayer::onFrameReady()
             }
             else {
                 const libvlc_time_t playbackTime = p.playback().get_time();
-                if( playbackTime == _currentTime && !_pausedFrameLoaded) {
+                if( playbackTime == _currentTime && !_pausedFrameLoaded ) {
                     _pausedFrameLoaded = true;
                     doCallCallback();
                 }
@@ -609,21 +609,6 @@ void JsVlcPlayer::onFrameReady()
                 }
             }
             break;
-
-        /*case ELoadVideoState::LOADED:
-            // Check if playback was resumed while getting frame.
-            if( p.is_playing() ) {
-                doPauseAtTime();
-                _loadVideoState = ELoadVideoState::GETTING;
-            }
-            else if( libvlc_Paused == p.get_state() ) {
-                const libvlc_time_t playbackTime = p.playback().get_time();
-                if (playbackTime == _loadVideoAtTime) {
-                    doCallCallback();
-                    _loadVideoState = ELoadVideoState::LOADED;
-                }
-            }
-            break;*/
         case ELoadVideoState::GETTING:
             vlc::playback& playback = p.playback();
             const libvlc_time_t playbackTime = playback.get_time();
@@ -839,10 +824,10 @@ void JsVlcPlayer::updateCurrentTime() {
         else {
             _lastTimeFrameReady = playbackTime;
 
-            if( playbackTime > _currentTime) {
+            if( playbackTime > _currentTime ) {
                 _currentTime = playbackTime;
             }
-      }
+        }
     }
 
     _lastTimeGlobalFrameReady = currentTimeGlobal;

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -296,6 +296,11 @@ void JsVlcPlayer::closeAll()
 
 JsVlcPlayer::JsVlcPlayer( v8::Local<v8::Object>& thisObject, const v8::Local<v8::Array>& vlcOpts ) :
     _libvlc( nullptr ),
+    _cppInput( nullptr ),
+    _cppAudio( nullptr ),
+    _cppVideo( nullptr ),
+    _cppSubtitles( nullptr ),
+    _cppPlaylist( nullptr ),
     _isPlaying( false ),
     _currentTime( 0 ),
     _lastTimeFrameReady( InvalidTime ),
@@ -1102,4 +1107,29 @@ v8::Local<v8::Object> JsVlcPlayer::subtitles()
 v8::Local<v8::Object> JsVlcPlayer::playlist()
 {
     return v8::Local<v8::Object>::New( v8::Isolate::GetCurrent(), _jsPlaylist );
+}
+
+void JsVlcPlayer::setInput( JsVlcInput& input )
+{
+    _cppInput = &input;
+}
+
+void JsVlcPlayer::setAudio( JsVlcAudio& audio )
+{
+    _cppAudio = &audio;
+}
+
+void JsVlcPlayer::setVideo( JsVlcVideo& video )
+{
+    _cppVideo = &video;
+}
+
+void JsVlcPlayer::setSubtitles( JsVlcSubtitles& subtitles )
+{
+    _cppSubtitles = &subtitles;
+}
+
+void JsVlcPlayer::setPlaylist( JsVlcPlaylist& playlist )
+{
+    _cppPlaylist = &playlist;
 }

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -237,7 +237,6 @@ void JsVlcPlayer::initJsApi( const v8::Handle<v8::Object>& exports )
     SET_RW_PROPERTY( instanceTemplate, "mute", &JsVlcPlayer::muted, &JsVlcPlayer::setMuted );
 
     NODE_SET_PROTOTYPE_METHOD( constructorTemplate, "load", jsLoad );
-    NODE_SET_PROTOTYPE_METHOD( constructorTemplate, "getFrameAtTime", jsGetFrameAtTime );
     SET_METHOD( constructorTemplate, "play", &JsVlcPlayer::play );
     SET_METHOD( constructorTemplate, "pause", &JsVlcPlayer::pause );
     SET_METHOD( constructorTemplate, "togglePause", &JsVlcPlayer::togglePause );
@@ -799,18 +798,6 @@ void JsVlcPlayer::jsLoad( const v8::FunctionCallbackInfo<v8::Value>& args )
 
         jsPlayer->load( *mrl, startPlaying );
     }
-}
-
-void JsVlcPlayer::jsGetFrameAtTime(const v8::FunctionCallbackInfo<v8::Value>& args)
-{
-    using namespace v8;
-
-    JsVlcPlayer* jsPlayer = ObjectWrap::Unwrap<JsVlcPlayer>( args.Holder() );
-
-    assert( args.Length() == 1 );
-    const double timeInSeconds = args[0]->ToNumber()->Value();
-    const libvlc_time_t timeInMs = static_cast<libvlc_time_t>( timeInSeconds * 1000.0 );
-    jsPlayer->getFrameAtTime( timeInMs );
 }
 
 void JsVlcPlayer::getJsCallback( v8::Local<v8::String> property,

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -854,7 +854,7 @@ double JsVlcPlayer::frames()
 {
     vlc::playback& playback = player().playback();
 
-    return static_cast<double>( static_cast<float>( playback.get_length() ) / playback.get_fps() );
+    return std::round( static_cast<double>( static_cast<float>( playback.get_length() ) / playback.get_fps() ) );
 }
 
 unsigned JsVlcPlayer::state()
@@ -937,7 +937,9 @@ void JsVlcPlayer::setTime( double time )
 
 double JsVlcPlayer::frame()
 {
-    return std::floor( static_cast<float>( time() ) / player().playback().get_fps() );
+    const double iFrame = std::round( static_cast<double>( static_cast<float>( time() ) / player().playback().get_fps() ) );
+
+    return std::min( iFrame, frames() );
 }
 
 void JsVlcPlayer::setFrame( double frame )
@@ -951,18 +953,22 @@ void JsVlcPlayer::previousFrame()
 {
     pause();
 
-    double iFrame = frame();
-    if( iFrame > 0 )
-        setFrame( iFrame - 1 );
+    const double iFrame = static_cast<double>( static_cast<float>( time() ) / player().playback().get_fps() );
+    if( iFrame > 0.0 )
+        setFrame( std::ceil( iFrame ) - 1 );
 }
 
 void JsVlcPlayer::nextFrame()
 {
     pause();
 
-    double iFrame = frame();
-    if( iFrame < frames() - 1 )
-        setFrame( iFrame + 1 );
+    vlc::playback& playback = player().playback();
+    const double frames = static_cast<double>( static_cast<float>( playback.get_length() ) / playback.get_fps() );
+    const double iFrame = static_cast<double>( static_cast<float>( time() ) / playback.get_fps() );
+    if( iFrame < frames - 1.0 )
+        setFrame( std::floor( iFrame ) + 1 );
+    else
+        setTime( static_cast<double>( playback.get_length() ) );
 }
 
 unsigned JsVlcPlayer::volume()

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -757,10 +757,15 @@ void JsVlcPlayer::updateCurrentTime() {
         const libvlc_time_t playbackTime = player().playback().get_time();
         if( _lastTimeFrameReady == playbackTime ) {
             _currentTime += currentTimeGlobal - _lastTimeGlobalFrameReady;
+        
+            const libvlc_time_t length = player().playback().get_length();
+            _currentTime = std::min( _currentTime, length );
         }
         else {
-            _currentTime = playbackTime;
             _lastTimeFrameReady = playbackTime;
+
+            if( playbackTime > _currentTime)
+                _currentTime = playbackTime;
       }
     }
 
@@ -1018,6 +1023,8 @@ void JsVlcPlayer::load( const std::string& mrl, bool startPlaying )
 
 void JsVlcPlayer::getFrameAtTime( libvlc_time_t time )
 {
+    assert( time >= 0 && time < player().playback().get_length() );
+
     _currentTime = time;
     _lastTimeFrameReady = InvalidTime;
     _lastTimeGlobalFrameReady = InvalidTime;

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -2,7 +2,9 @@
 
 #include <chrono>
 #include <string.h>
+#include <cmath>
 #include <thread>
+#include "JsVlcPlayer.h"
 
 #include "NodeTools.h"
 #include "JsVlcInput.h"
@@ -817,7 +819,7 @@ void JsVlcPlayer::updateCurrentTime() {
         const libvlc_time_t playbackTime = player().playback().get_time();
         if( _lastTimeFrameReady == playbackTime ) {
             _currentTime += currentTimeGlobal - _lastTimeGlobalFrameReady;
-        
+
             const libvlc_time_t length = player().playback().get_length();
             _currentTime = std::min( _currentTime, length );
         }
@@ -977,7 +979,7 @@ double JsVlcPlayer::time()
 {
     assert( _currentTime >= 0.0 && _currentTime <= length() );
 
-    return static_cast<double>( _currentTime ); 
+    return static_cast<double>( _currentTime );
 }
 
 void JsVlcPlayer::setTime( double time )

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -962,7 +962,7 @@ void JsVlcPlayer::nextFrame()
 
     double iFrame = frame();
     if( iFrame < frames() - 1 )
-        setFrame(iFrame + 1);
+        setFrame( iFrame + 1 );
 }
 
 unsigned JsVlcPlayer::volume()

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -301,7 +301,7 @@ JsVlcPlayer::JsVlcPlayer( v8::Local<v8::Object>& thisObject, const v8::Local<v8:
     _lastTimeFrameReady( InvalidTime ),
     _lastTimeGlobalFrameReady( InvalidTime ),
     _getFrameState( EGetFrameState::NOT_USED ),
-    _getFrameTime( InvalidTime )
+    _getFrameAtTime( InvalidTime )
 {
     Wrap( thisObject );
 
@@ -589,7 +589,7 @@ void JsVlcPlayer::onFrameReady()
         case EGetFrameState::GETTING:
             if( libvlc_Paused == p.get_state() ) {
                 const libvlc_time_t playbackTime = p.playback().get_time();
-                if( playbackTime ==_getFrameTime ) {
+                if( playbackTime == _getFrameAtTime ) {
                     doCallCallback();
                     _getFrameState = EGetFrameState::SENT;
                 }
@@ -602,7 +602,6 @@ void JsVlcPlayer::onFrameReady()
             // Check if playback was resumed while getting frame.
             if( p.is_playing() ) {
                 doPauseAtTime();
-
                 _getFrameState = EGetFrameState::GETTING;
             }
             break;
@@ -782,7 +781,7 @@ void JsVlcPlayer::doPauseAtTime() {
     vlc::player& p = player();
 
     p.pause();
-    p.playback().set_time( _getFrameTime );
+    p.playback().set_time( _getFrameAtTime );
 }
 
 void JsVlcPlayer::jsLoad( const v8::FunctionCallbackInfo<v8::Value>& args )
@@ -905,7 +904,7 @@ void JsVlcPlayer::setPosition( double position )
     _lastTimeFrameReady = InvalidTime;
     _lastTimeGlobalFrameReady = InvalidTime;
     _getFrameState = EGetFrameState::NOT_USED;
-    _getFrameTime = InvalidTime;
+    _getFrameAtTime = InvalidTime;
 
     if( _isPlaying )
         player().playback().set_position( static_cast<float>( position ) );
@@ -928,7 +927,7 @@ void JsVlcPlayer::setTime( double time )
     _lastTimeFrameReady = InvalidTime;
     _lastTimeGlobalFrameReady = InvalidTime;
     _getFrameState = EGetFrameState::NOT_USED;
-    _getFrameTime = InvalidTime;
+    _getFrameAtTime = InvalidTime;
 
     if( _isPlaying )
         player().playback().set_time( _currentTime );
@@ -992,7 +991,7 @@ void JsVlcPlayer::load( const std::string& mrl, bool startPlaying )
     _lastTimeFrameReady = InvalidTime;
     _lastTimeGlobalFrameReady = InvalidTime;
     _getFrameState = EGetFrameState::NOT_USED;
-    _getFrameTime = InvalidTime;
+    _getFrameAtTime = InvalidTime;
 
     vlc::player& p = player();
 
@@ -1017,18 +1016,18 @@ void JsVlcPlayer::getFrameAtTime( libvlc_time_t time )
     _lastTimeFrameReady = InvalidTime;
     _lastTimeGlobalFrameReady = InvalidTime;
     _getFrameState = EGetFrameState::GETTING;
-    _getFrameTime = time;
+    _getFrameAtTime = time;
 
     vlc::player& p = player();
     p.play();
-    p.playback().set_time( _getFrameTime );
+    p.playback().set_time( _getFrameAtTime );
 }
 
 void JsVlcPlayer::play()
 {
     _isPlaying = true;
     _getFrameState = EGetFrameState::NOT_USED;
-    _getFrameTime = InvalidTime;
+    _getFrameAtTime = InvalidTime;
 
     player().play();
 }
@@ -1037,7 +1036,7 @@ void JsVlcPlayer::pause()
 {
     _isPlaying = false;
     _getFrameState = EGetFrameState::NOT_USED;
-    _getFrameTime = InvalidTime;
+    _getFrameAtTime = InvalidTime;
 
     player().pause();
 }
@@ -1046,7 +1045,7 @@ void JsVlcPlayer::togglePause()
 {
     _isPlaying = !_isPlaying;
     _getFrameState = EGetFrameState::NOT_USED;
-    _getFrameTime = InvalidTime;
+    _getFrameAtTime = InvalidTime;
 
     player().togglePause();
 }
@@ -1057,7 +1056,7 @@ void JsVlcPlayer::stop()
     _lastTimeFrameReady = InvalidTime;
     _lastTimeGlobalFrameReady = InvalidTime;
     _getFrameState = EGetFrameState::NOT_USED;
-    _getFrameTime = InvalidTime;
+    _getFrameAtTime = InvalidTime;
 
     player().stop();
 }

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -1077,6 +1077,10 @@ void JsVlcPlayer::play()
 
 void JsVlcPlayer::playReverse()
 {
+    // Avoid creating more than one thread to do the same.
+    if( _reversePlayback )
+        return;
+
     _isPlaying = true;
     _reversePlayback = true;
 
@@ -1101,6 +1105,7 @@ void JsVlcPlayer::playReverse()
 void JsVlcPlayer::pause()
 {
     _isPlaying = false;
+    _reversePlayback = false;
 
     player().pause();
 }
@@ -1108,6 +1113,7 @@ void JsVlcPlayer::pause()
 void JsVlcPlayer::togglePause()
 {
     _isPlaying = !_isPlaying;
+    _reversePlayback = false;
 
     player().togglePause();
 }
@@ -1115,8 +1121,8 @@ void JsVlcPlayer::togglePause()
 void JsVlcPlayer::stop()
 {
     _isPlaying = false;
-    setRateReverse( 1.0 );
     _reversePlayback = false;
+    setRateReverse( 1.0 );
 
     setCurrentTime( 0 );
     player().stop();

--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -98,8 +98,8 @@ public:
     void setMuted( bool );
 
     void load( const std::string& mrl, bool startPlaying );
-    void getFrameAtTime( libvlc_time_t time );
     void play();
+    void playReverse();
     void pause();
     void togglePause();
     void stop();
@@ -150,9 +150,15 @@ private:
     void callCallback( Callbacks_e callback,
                        std::initializer_list<v8::Local<v8::Value> > list = std::initializer_list<v8::Local<v8::Value> >() );
 
-    void updateCurrentTime();
+    void loadVideoAtTime( libvlc_time_t time );
+    void doPauseAtLoadTime();
     void doCallCallback();
-    void doPauseAtTime();
+
+    void updateCurrentTime();
+    void setCurrentTime( libvlc_time_t time );
+
+    double rateReverse();
+    void setRateReverse( double rateReverse );
 
 protected:
     void* onFrameSetup( const RV32VideoFrame& ) override;
@@ -161,16 +167,17 @@ protected:
     void onFrameCleanup() override;
 
 private:
-    enum class EGetFrameState
+    enum class ELoadVideoState
     {
-        NOT_USED,
+        UNLOADED,
         GETTING,
-        SENT
+        LOADED
     };
 
     static v8::Persistent<v8::Function> _jsConstructor;
     static std::set<JsVlcPlayer*> _instances;
 
+    static const unsigned MaxSanityChecks = 5;
     static const libvlc_time_t InvalidTime = ~0;
 
     libvlc_instance_t* _libvlc;
@@ -200,11 +207,15 @@ private:
     uv_timer_t _errorTimer;
 
     bool _isPlaying;
+    bool _reversePlayback;
+
     libvlc_time_t _currentTime;
+    bool _pausedFrameLoaded;
 
     libvlc_time_t _lastTimeFrameReady;
     libvlc_time_t _lastTimeGlobalFrameReady;
 
-    EGetFrameState _getFrameState;
-    libvlc_time_t _getFrameAtTime;
+    ELoadVideoState _loadVideoState;
+    libvlc_time_t _loadVideoAtTime;
+    unsigned _videoLoadedSanityChecks;
 };

--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -64,6 +64,7 @@ public:
 
     bool playing();
     double length();
+    double frames();
     unsigned state();
 
     v8::Local<v8::Value> getVideoFrame();
@@ -77,6 +78,12 @@ public:
 
     double time();
     void setTime( double );
+
+    double frame();
+    void setFrame( double );
+
+    void previousFrame();
+    void nextFrame();
 
     unsigned volume();
     void setVolume( unsigned );

--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -188,5 +188,5 @@ private:
     libvlc_time_t _lastTimeGlobalFrameReady;
 
     EGetFrameState _getFrameState;
-    libvlc_time_t _getFrameTime;
+    libvlc_time_t _getFrameAtTime;
 };

--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -14,6 +14,12 @@
 
 #include "VlcVideoOutput.h"
 
+class JsVlcInput;
+class JsVlcAudio;
+class JsVlcVideo;
+class JsVlcSubtitles;
+class JsVlcPlaylist;
+
 class JsVlcPlayer :
     public node::ObjectWrap,
     private VlcVideoOutput,
@@ -105,6 +111,12 @@ public:
     v8::Local<v8::Object> subtitles();
     v8::Local<v8::Object> playlist();
 
+    void setInput( JsVlcInput& input );
+    void setAudio( JsVlcAudio& audio );
+    void setVideo( JsVlcVideo& video );
+    void setSubtitles( JsVlcSubtitles& subtitles );
+    void setPlaylist( JsVlcPlaylist& playlist );
+
     vlc::player& player()
         { return _player; }
 
@@ -178,6 +190,12 @@ private:
     v8::UniquePersistent<v8::Object> _jsVideo;
     v8::UniquePersistent<v8::Object> _jsSubtitles;
     v8::UniquePersistent<v8::Object> _jsPlaylist;
+
+    JsVlcInput* _cppInput;
+    JsVlcAudio* _cppAudio;
+    JsVlcVideo* _cppVideo;
+    JsVlcSubtitles* _cppSubtitles;
+    JsVlcPlaylist* _cppPlaylist;
 
     uv_timer_t _errorTimer;
 

--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -53,7 +53,6 @@ public:
     static void initJsApi( const v8::Handle<v8::Object>& exports );
 
     static void jsLoad( const v8::FunctionCallbackInfo<v8::Value>& args );
-    static void jsGetFrameAtTime( const v8::FunctionCallbackInfo<v8::Value>& args );
 
     static void getJsCallback( v8::Local<v8::String> property,
                                const v8::PropertyCallbackInfo<v8::Value>& info,

--- a/src/JsVlcPlaylist.cpp
+++ b/src/JsVlcPlaylist.cpp
@@ -100,6 +100,7 @@ JsVlcPlaylist::JsVlcPlaylist( v8::Local<v8::Object>& thisObject, JsVlcPlayer* js
 {
     Wrap( thisObject );
 
+    _jsPlayer->setPlaylist( *this );
     _jsItems = JsVlcPlaylistItems::create( *jsPlayer );
 }
 

--- a/src/JsVlcSubtitles.cpp
+++ b/src/JsVlcSubtitles.cpp
@@ -76,6 +76,8 @@ JsVlcSubtitles::JsVlcSubtitles( v8::Local<v8::Object>& thisObject, JsVlcPlayer* 
     _jsPlayer( jsPlayer )
 {
     Wrap( thisObject );
+
+    _jsPlayer->setSubtitles( *this );
 }
 
 std::string JsVlcSubtitles::description( uint32_t index )

--- a/src/JsVlcVideo.cpp
+++ b/src/JsVlcVideo.cpp
@@ -83,6 +83,7 @@ JsVlcVideo::JsVlcVideo( v8::Local<v8::Object>& thisObject, JsVlcPlayer* jsPlayer
 {
     Wrap( thisObject );
 
+    _jsPlayer->setVideo( *this );
     _jsDeinterlace = JsVlcDeinterlace::create( *jsPlayer );
 }
 


### PR DESCRIPTION
The aim of this PR is improve video playback in a general way:
 - Rename `play` method by `load` when loading it.
 - By parameter, decide if start playing a video when loading or not.
 - Current playback time from VLC is now updated continuously.
 - Show a frame at time/position accurately.
 - Frame-accuracy feature added and exposed to Javascript.
 - Playback reverse/backward feature at any speed added and exposed to Javascript.