### PR TITLE
Load video and start playing

### DIFF
--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -931,7 +931,7 @@ double JsVlcPlayer::frames()
 {
     vlc::playback& playback = player().playback();
 
-    return std::round( static_cast<double>( static_cast<float>( playback.get_length() ) / playback.get_fps() ) );
+    return std::round( static_cast<double>( static_cast<float>( playback.get_length() ) * playback.get_fps() / 1000.0f ) );
 }
 
 unsigned JsVlcPlayer::state()
@@ -996,7 +996,7 @@ void JsVlcPlayer::setTime( double time )
 
 double JsVlcPlayer::frame()
 {
-    const double iFrame = std::round( static_cast<double>( static_cast<float>( time() ) / player().playback().get_fps() ) );
+    const double iFrame = std::round( static_cast<double>( static_cast<float>( time() ) * player().playback().get_fps() / 1000.0f ) );
 
     return std::min( iFrame, frames() );
 }

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -778,8 +778,6 @@ void JsVlcPlayer::callCallback( Callbacks_e callback,
 
 void JsVlcPlayer::loadVideoAtTime( libvlc_time_t time )
 {
-    assert( time >= 0 && time <= player().playback().get_length() );
-
     setCurrentTime( time );
 
     _loadVideoState = ELoadVideoState::GETTING;
@@ -837,9 +835,7 @@ void JsVlcPlayer::updateCurrentTime() {
 
 void JsVlcPlayer::setCurrentTime( libvlc_time_t time )
 {
-    assert( time >= 0 && time <= player().playback().get_length() );
-
-    _currentTime = time;
+    _currentTime = std::max( 0ll, std::min( time, player().playback().get_length() ) );
 
     _lastTimeFrameReady = InvalidTime;
     _lastTimeGlobalFrameReady = InvalidTime;
@@ -974,7 +970,7 @@ double JsVlcPlayer::position()
 
 void JsVlcPlayer::setPosition( double position )
 {
-    assert( position >= 0.0 && position <= 1.0 );
+    position = std::max( 0.0, std::min( position, 1.0 ) );
 
     setCurrentTime( static_cast<libvlc_time_t>( position * length() ) );
     player().playback().set_position( static_cast<float>( position ) );
@@ -989,8 +985,6 @@ double JsVlcPlayer::time()
 
 void JsVlcPlayer::setTime( double time )
 {
-    assert( time >= 0.0 && time <= length() );
-
     setCurrentTime( static_cast<libvlc_time_t>( time ) );
     player().playback().set_time( _currentTime );
 }
@@ -1004,7 +998,7 @@ double JsVlcPlayer::frame()
 
 void JsVlcPlayer::setFrame( double frame )
 {
-    assert( frame >= 0.0 && frame <= frames() );
+    frame = std::max( 0.0, std::min( frame, frames() ) );
 
     setTime( frame * player().playback().get_fps() );
 }

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -311,7 +311,7 @@ JsVlcPlayer::JsVlcPlayer( v8::Local<v8::Object>& thisObject, const v8::Local<v8:
     _pausedFrameLoaded( false ),
     _lastTimeFrameReady( InvalidTime ),
     _lastTimeGlobalFrameReady( InvalidTime ),
-    _loadVideoState( ELoadVideoState::UNLOADED ),
+    _loadVideoState( ELoadVideoState::LOADED ),
     _loadVideoAtTime( InvalidTime ),
     _videoLoadedSanityChecks( MaxSanityChecks )
 {

--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -177,6 +177,7 @@ private:
     static v8::Persistent<v8::Function> _jsConstructor;
     static std::set<JsVlcPlayer*> _instances;
 
+    // Sanity checks are used because LibVLC sometimes sends a previous frame, not the right one that we want.
     static const unsigned MaxSanityChecks = 5;
     static const libvlc_time_t InvalidTime = ~0;
 
@@ -211,6 +212,7 @@ private:
 
     libvlc_time_t _currentTime;
     bool _pausedFrameLoaded;
+    unsigned _pausedFrameLoadedSanityChecks;
 
     libvlc_time_t _lastTimeFrameReady;
     libvlc_time_t _lastTimeGlobalFrameReady;

--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -170,9 +170,8 @@ protected:
 private:
     enum class ELoadVideoState
     {
-        UNLOADED,
-        GETTING,
-        LOADED
+        LOADED,
+        GETTING
     };
 
     static v8::Persistent<v8::Function> _jsConstructor;


### PR DESCRIPTION
`OnFrameReady` event was never called when a video was loaded and had to be played directly. Variable `_loadVideoState` was always in `ELoadVideoState::UNLOADED` state (which was not needed).