### PR TITLE
Taking into account speed rate when updating time

### DIFF
--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -821,7 +821,7 @@ void JsVlcPlayer::updateCurrentTime() {
     if( _isPlaying && !_reversePlayback ) {
         const libvlc_time_t playbackTime = player().playback().get_time();
         if( _lastTimeFrameReady == playbackTime ) {
-            _currentTime += currentTimeGlobal - _lastTimeGlobalFrameReady;
+            _currentTime += static_cast<libvlc_time_t>( static_cast<double>( currentTimeGlobal - _lastTimeGlobalFrameReady ) * _cppInput->rate() );
 
             const libvlc_time_t length = player().playback().get_length();
             _currentTime = std::min( _currentTime, length );


### PR DESCRIPTION
We can't get the current time of the video playback from LibVLC because the library doesn't update this value when a new frame comes (LibVLC updates it each ~200ms or so). For that reason, we compute manually this value, but we weren't taking into account speed rate, so time/frame that we read, it was wrong.