### PR TITLE
Fran/frame ready with more arguments

### DIFF
--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -831,6 +831,10 @@ void JsVlcPlayer::setRateReverse( double rateReverse )
     _cppInput->setRateReverse( rateReverse );
 }
 
+double JsVlcPlayer::decimalFrame() {
+  return static_cast<double>( static_cast<float>( time() ) / ( 1000.0f / player().playback().get_fps() ) );
+}
+
 void JsVlcPlayer::jsLoad( const v8::FunctionCallbackInfo<v8::Value>& args )
 {
     using namespace v8;
@@ -979,7 +983,7 @@ void JsVlcPlayer::setTime( double time )
 
 double JsVlcPlayer::frame()
 {
-    const double iFrame = std::round( static_cast<double>( static_cast<float>( time() ) * player().playback().get_fps() / 1000.0f ) );
+    const double iFrame = std::round( decimalFrame() );
 
     return std::min( iFrame, frames() );
 }
@@ -995,7 +999,7 @@ void JsVlcPlayer::previousFrame()
 {
     pause();
 
-    const double iFrame = static_cast<double>( static_cast<float>( time() ) / player().playback().get_fps() );
+    const double iFrame = decimalFrame();
     if( iFrame > 0.0 )
         setFrame( std::ceil( iFrame ) - 1 );
 }
@@ -1006,7 +1010,7 @@ void JsVlcPlayer::nextFrame()
 
     vlc::playback& playback = player().playback();
     const double frames = static_cast<double>( static_cast<float>( playback.get_length() ) / playback.get_fps() );
-    const double iFrame = static_cast<double>( static_cast<float>( time() ) / playback.get_fps() );
+    const double iFrame = decimalFrame();
     if( iFrame < frames - 1.0 )
         setFrame( std::floor( iFrame ) + 1 );
     else

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -780,7 +780,11 @@ void JsVlcPlayer::doCallCallback() {
     HandleScope scope( isolate );
 
     assert( !_jsFrameBuffer.IsEmpty() ); //FIXME! maybe it worth add condition here
-    callCallback( CB_FrameReady, { Local<Value>::New( Isolate::GetCurrent(), _jsFrameBuffer ) } );
+    callCallback( CB_FrameReady, {
+      Local<Value>::New( isolate, _jsFrameBuffer ),
+      Number::New( isolate, frame() ),
+      Number::New( isolate, time() )
+    } );
 }
 
 void JsVlcPlayer::updateCurrentTime() {

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -988,7 +988,7 @@ void JsVlcPlayer::setFrame( double frame )
 {
     frame = std::max( 0.0, std::min( frame, frames() ) );
 
-    setTime( frame * player().playback().get_fps() );
+    setTime( frame * 1000.0f / player().playback().get_fps() );
 }
 
 void JsVlcPlayer::previousFrame()

--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -159,6 +159,8 @@ private:
     double rateReverse();
     void setRateReverse( double rateReverse );
 
+    double decimalFrame();
+
 protected:
     void* onFrameSetup( const RV32VideoFrame& ) override;
     void* onFrameSetup( const I420VideoFrame& ) override;


### PR DESCRIPTION
In this pull request, we pass the frame and the time alongside frame buffer on `frame-ready` event. Moreover, we have fixed an error that we had computing the proper frame number.