### PR TITLE
Minor fixes added to video player

### DIFF
--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -1097,8 +1097,14 @@ void JsVlcPlayer::playReverse()
                 const double msPerFrame = static_cast<double>( 1000.0f / playback.get_fps() );
                 const libvlc_time_t msToGoBack = static_cast<libvlc_time_t>( msPerFrame * rateReverse() );
 
-                setTime( static_cast<double>( _currentTime - msToGoBack ) );
-                std::this_thread::sleep_for( std::chrono::milliseconds( static_cast<libvlc_time_t>( msPerFrame ) ) );
+                if( _currentTime - msToGoBack >= 0 ) {
+                    setTime( static_cast<double>( _currentTime - msToGoBack ) );
+                    std::this_thread::sleep_for( std::chrono::milliseconds( static_cast<libvlc_time_t>( msPerFrame ) ) );
+                }
+                else {
+                    _isPlaying = false;
+                    _reversePlayback = false;
+                }
             }
         }
     );

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -805,7 +805,8 @@ void JsVlcPlayer::updateCurrentTime() {
             _lastTimeFrameReady = playbackTime;
 
             if( playbackTime > _currentTime ) {
-                _currentTime = playbackTime;
+                const libvlc_time_t length = player().playback().get_length();
+                _currentTime = std::min( playbackTime, length );
             }
         }
     }

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -1043,6 +1043,7 @@ void JsVlcPlayer::setMuted( bool mute )
 
 void JsVlcPlayer::load( const std::string& mrl, bool startPlaying, unsigned atTime )
 {
+    stop();
     setCurrentTime( static_cast<libvlc_time_t>( atTime ) );
     setRateReverse( 1.0 );
     _reversePlayback = false;

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -603,7 +603,7 @@ void JsVlcPlayer::onFrameReady()
             else if( _performSeek ) {
               vlc::playback& playback = p.playback();
               const libvlc_time_t playbackTime = playback.get_time();
-              if( 100.0f == _bufferingValue && playbackTime == _currentTime ) {
+              if( playbackTime == _currentTime ) {
                   doCallCallback();
 
                   if( 0u == --_seekedFrameLoadedSanityChecks )
@@ -619,14 +619,12 @@ void JsVlcPlayer::onFrameReady()
             if( libvlc_Paused == p.get_state() ) {
                 vlc::playback& playback = p.playback();
                 const libvlc_time_t playbackTime = playback.get_time();
-                if( 100.0f == _bufferingValue ) {
-                    if( playbackTime == _currentTime ) {
-                        doCallCallback();
-                        _loadVideoState = ELoadVideoState::LOADED;
-                    }
-                    else
-                        playback.set_time( _currentTime );
+                if( playbackTime == _currentTime ) {
+                    doCallCallback();
+                    _loadVideoState = ELoadVideoState::LOADED;
                 }
+                else
+                    playback.set_time( _currentTime );
             }
             else {
                 p.pause();


### PR DESCRIPTION
The main addition in this PR is the last commit, where buffering value is not already used. It's not used because is unreliable since seeking at the end is not always 100 and that created an infinite loop.