### PR TITLE
Send callback when video reaches the beginning on playing reverse

### DIFF
--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -39,6 +39,7 @@ class JsVlcPlayer :
         CB_MediaPlayerStopped,
         CB_MediaPlayerForward,
         CB_MediaPlayerBackward,
+        CB_MediaPlayerBeginReached,
         CB_MediaPlayerEndReached,
         CB_MediaPlayerEncounteredError,
 


### PR DESCRIPTION
In this pull request, we have added `BeginReached` event to LibVLC, which notifies when video reaches the beginning on playing reverse.