### PR TITLE
Start video playback at specified time fix

### DIFF
--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -1065,6 +1065,7 @@ void JsVlcPlayer::load( const std::string& mrl, bool startPlaying, unsigned atTi
         p.play( idx );
         if( startPlaying ) {
           _loadVideoState = ELoadVideoState::LOADED;
+          p.playback().set_time( _currentTime );
         }
         else {
           _loadVideoState = ELoadVideoState::GETTING;


### PR DESCRIPTION
When loading a video, we can pass a time as argument to start playback at that point. This feature only worked when video is paused.