### PR TITLE
Avoid showing first frame when loading and playing a new video at specified time

### DIFF
--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -209,6 +209,7 @@ private:
 
     uv_timer_t _errorTimer;
 
+    bool _startPlaying;
     bool _isPlaying;
     bool _reversePlayback;
 

--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -213,6 +213,7 @@ private:
     bool _isPlaying;
     bool _reversePlayback;
 
+    libvlc_time_t _loadingTime;
     libvlc_time_t _currentTime;
     bool _performSeek;
     unsigned _seekedFrameLoadedSanityChecks;


### PR DESCRIPTION
Before this change, when playing a video and loading a new one also being played, first frame of it was shown. In order to avoid it, we won't play the new video until the required starting frame is loaded. Moreover, we take into account the time spent loading the proper starting frame and we sync the video according to it. 