### PR TITLE
Set cmake-js version to avoid bug when building

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "ajv": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-      "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
         "fast-deep-equal": "2.0.1",
         "fast-json-stable-stringify": "2.0.0",
@@ -110,9 +110,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.41",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.41.tgz",
-      "integrity": "sha512-d5AT9lMTYJ/ZE/4gzxb+5ttPcRWljVsvv7lF1w9KzkPhVUhBtHrjDo1J8swfZKepfLsliDhYa31zRYwcD0Yg9w=="
+      "version": "1.6.43",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.43.tgz",
+      "integrity": "sha512-9dULc9jsKmXl0Aeunug8wbF+58n+hQoFjqClN7WeZwGLh0XJUWyJJ9Ee+Ep+Ql/J9fRsTVaeThp8MhiCCrY0Jg=="
     },
     "binary": {
       "version": "0.3.0",
@@ -191,9 +191,9 @@
       }
     },
     "cmake-js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-5.1.0.tgz",
-      "integrity": "sha512-bU7sgkRGkHEBdYopc0t+WawcJEMg6WEFuXt9c1rqAbLFSplndRE6y4XvlO/5pCgbqKtQM5zARQhBG+dUX/nWcw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-4.0.1.tgz",
+      "integrity": "sha512-ShCnSfCmcy9LfFomcMbQJuQ+hnanlMZbOqfiA8EmkYlW2uUwi4/m4/Rt+mOFmAdvNceP3bTLjHymYNNsM4tjFQ==",
       "requires": {
         "bluebird": "3.5.3",
         "debug": "4.1.1",
@@ -448,7 +448,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "6.9.1",
+        "ajv": "6.10.0",
         "har-schema": "2.0.0"
       }
     },
@@ -972,7 +972,7 @@
       "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
       "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
       "requires": {
-        "big-integer": "1.6.41",
+        "big-integer": "1.6.43",
         "binary": "0.3.0",
         "bluebird": "3.4.7",
         "buffer-indexof-polyfill": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "bindings": "~1.2.1",
-    "cmake-js": "*"
+    "cmake-js": "^4.0.0"
   },
   "scripts": {
     "install": "node rebuild.js"


### PR DESCRIPTION
cmake-js has a bug in 5.1.0 version when building on Windows, so in order to avoid it we set a version where we know it's working.

The description of the issue: https://github.com/Microsoft/napajs/issues/283.