### PR TITLE
Conversion time-frame could not match

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webchimera.js",
   "description": "libvlc binding for node.js/io.js/NW.js/Electron",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "license": "LGPL-2.1",
   "author": "Sergey Radionov <rsatom@gmail.com>",
   "keywords": [

--- a/src/JsVlcPlayer.h
+++ b/src/JsVlcPlayer.h
@@ -72,6 +72,7 @@ public:
     bool playing();
     bool playingReverse();
     double length();
+    double fps();
     double frames();
     unsigned state();
 
@@ -99,7 +100,7 @@ public:
     bool muted();
     void setMuted( bool );
 
-    void load( const std::string& mrl, bool startPlaying, bool startPlayingReverse, unsigned atTime );
+    void load( const std::string& mrl, bool startPlaying, bool startPlayingReverse, unsigned atTime, double withFps );
     void play();
     void playReverse();
     void pause();
@@ -234,4 +235,8 @@ private:
 
     ELoadVideoState _loadVideoState;
     float _bufferingValue;
+
+    // Perform conversions from time to frame using this FPS value. Useful when we don't want to use the
+    // internal FPS value, average frame rate, and we prefer using another one, e.g. raw frame rate.
+    float _withFps;
 };


### PR DESCRIPTION
In VLC, we perform conversions from time to frame using the `get_fps` method, which uses **average frame-rate** value. However, we might need another value, e.g. **raw frame-rate**. In this pull request, we allow to pass any FPS value to perform those computations.